### PR TITLE
AWSリージョン指定をbotoセッションから取得する

### DIFF
--- a/scripts/ecsub/aws.py
+++ b/scripts/ecsub/aws.py
@@ -247,8 +247,7 @@ class Aws_ecsub_control:
         #return json.loads(response)["Account"]
         
     def _get_region(self):
-        response = self._subprocess_communicate("aws configure get region")
-        return response.rstrip("\n")
+        return boto3.session.Session().region_name
 
     def _json_load(self, json_file):
         


### PR DESCRIPTION
AWSリージョンの指定をawscliのconfigファイルから得ていた箇所をbotoセッションインスタンスから取得するように変更します。
これにより、環境変数`AWS_DEFAULT_REGION`等からリージョン指定をすることができるようになります。

botoが値の解決を試みる順番は[ドキュメント](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials)の通りです。
環境変数がない場合は従来通りconfigファイルを参照します。

> 1. Passing credentials as parameters in the boto.client() method
> 2. Passing credentials as parameters when creating a Session object
> 3. Environment variables
> 4. Shared credential file (~/.aws/credentials)
> 5. AWS config file (~/.aws/config)
> 6. Assume Role provider
> 7. Boto2 config file (/etc/boto.cfg and ~/.boto)
> 8. Instance metadata service on an Amazon EC2 instance that has an IAM role configured.
