### PR TITLE
ECSインスタンスロール名を指定可能にする

### DIFF
--- a/ecsub
+++ b/ecsub
@@ -38,6 +38,7 @@ def main():
         submit_parser.add_argument("--aws-s3-bucket", metavar = "s3://output/bucket", help = "AWS your S3 bucket", type = str, required=True)
         submit_parser.add_argument("--aws-ec2-instance-type", metavar = "t2.micro", help = "AWS instance type", type = str, default = default.aws_ec2_instance_type)
         submit_parser.add_argument("--aws-ec2-instance-type-list", metavar = "t3.micro,t2.micro", help = "AWS instance types, split with ',' ", type = str, default = default.aws_ec2_instance_type_list)
+        submit_parser.add_argument("--aws-ecs-instance-role-name", metavar="ecsInstanceRole", help="AWS ECS instance role name", type=str, default=default.aws_ecs_instance_role_name)
         submit_parser.add_argument("--disk-size", metavar = 22, help = "AWS disk size (GiB)", type = int, default = default.disk_size)
         submit_parser.add_argument("--processes", metavar = 20, help = "maximum multi processes", type = int, default = default.processes)
         submit_parser.add_argument("--aws-security-group-id", metavar = "sg-ab123456", help = "AWS your security_group_id", type = str, default =  default.aws_security_group_id)

--- a/scripts/ecsub/aws.py
+++ b/scripts/ecsub/aws.py
@@ -33,7 +33,8 @@ class Aws_ecsub_control:
         self.aws_key_auto = None
         self.aws_key_name = params["aws_key_name"]
         self.aws_security_group_id = params["aws_security_group_id"]
-        
+        self.aws_ecs_instance_role_name = params['aws_ecs_instance_role_name']
+
         self.wdir = params["wdir"].rstrip("/")
         self.cluster_name = params["cluster_name"]
         self.setx = params["setx"]
@@ -361,8 +362,10 @@ class Aws_ecsub_control:
 
     def register_task_definition(self):
 
-        ECSTASKROLE = "arn:aws:iam::{AWS_ACCOUNTID}:role/ecsInstanceRole".format(
-            AWS_ACCOUNTID = self.aws_accountid)
+        ECSTASKROLE = \
+            "arn:aws:iam::{AWS_ACCOUNTID}:role/{AWS_ECS_INSTANCE_ROLE_NAME}"\
+            .format(AWS_ACCOUNTID=self.aws_accountid,
+                    AWS_ECS_INSTANCE_ROLE_NAME=self.aws_ecs_instance_role_name)
 
         IMAGE_ARN = self.image
         if self.use_amazon_ecr:
@@ -619,7 +622,7 @@ echo "aws configure set region "\$AWSREGION >> /external/aws_confgure.sh
             + " --security-group-ids {SECURITYGROUPID}" \
             + " --key-name {KEY_NAME}" \
             + " --user-data file://{userdata}" \
-            + " --iam-instance-profile Name=ecsInstanceRole" \
+            + " --iam-instance-profile Name={AWS_ECS_INSTANCE_ROLE_NAME}" \
             + " --instance-type {instance_type}" \
             + " --block-device-mappings file://{json}" \
             + " --count 1 {subnet_id}" \
@@ -632,6 +635,7 @@ echo "aws configure set region "\$AWSREGION >> /external/aws_confgure.sh
             KEY_NAME = self.aws_key_name,
             subnet_id = subnet_id,
             instance_type = self.task_param[no]["aws_ec2_instance_type"],
+            AWS_ECS_INSTANCE_ROLE_NAME=self.aws_ecs_instance_role_name,
             json = bd_mappings_file,
             INDEX = no,
             userdata = userdata_file,
@@ -840,7 +844,7 @@ echo "aws configure set region "\$AWSREGION >> /external/aws_confgure.sh
             "SecurityGroupIds": [ self.aws_security_group_id ],
             "BlockDeviceMappings": block_device_mappings,
             "IamInstanceProfile": {
-                "Name": "ecsInstanceRole"
+                "Name": self.aws_ecs_instance_role_name
             },
             "ImageId": self.aws_ami_id,
             "InstanceType": self.task_param[no]["aws_ec2_instance_type"],

--- a/scripts/ecsub/submit.py
+++ b/scripts/ecsub/submit.py
@@ -789,6 +789,7 @@ class Argments:
         self.aws_s3_bucket = ""
         self.aws_ec2_instance_type = ""
         self.aws_ec2_instance_type_list = ""
+        self.aws_ecs_instance_role_name = "ecsInstanceRole"
         self.disk_size = 22
         self.processes = 20
         self.aws_security_group_id = ""


### PR DESCRIPTION
ECSのインスタンスロール名について、デフォルトの`ecsInstanceRole`以外を指定できるように変更します。
新規オプション`--aws-ecs-instance-role-name`を設けています。指定がない場合は従来通り`ecsInstanceRole`が用いられます。