### PR TITLE
ECSコンテナインスタンスの起動時にAmazon Linux 2を使用する

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ optional arguments:
                         instance types, split with ','
   --aws-ecs-instance-role-name ecsInstanceRole
                         AWS ECS instance role name
-  --disk-size 22        AWS disk size (GiB)
+  --disk-size 22        Size of extra disk space in GiB for container layers and mounted volumes, excluding 30GiB for OS and docker runtime
   --processes 20        maximum multi processes
   --aws-security-group-id sg-ab123456,sg-ab456789
                         AWS your security_group_ids, split with ','

--- a/ecsub
+++ b/ecsub
@@ -39,7 +39,12 @@ def main():
         submit_parser.add_argument("--aws-ec2-instance-type", metavar = "t3.micro,t2.micro", help = "AWS instance types, split with ',' ", type = str, default = default.aws_ec2_instance_type)
         submit_parser.add_argument("--aws-ec2-instance-type-list", metavar = "t3.micro,t2.micro", help = "(Deprecated as it is to be decommissioned.) AWS instance types, split with ',' ", type = str, default = default.aws_ec2_instance_type_list)
         submit_parser.add_argument("--aws-ecs-instance-role-name", metavar="ecsInstanceRole", help="AWS ECS instance role name", type=str, default=default.aws_ecs_instance_role_name)
-        submit_parser.add_argument("--disk-size", metavar = 22, help = "AWS disk size (GiB)", type = int, default = default.disk_size)
+        submit_parser.add_argument("--disk-size", metavar='22',
+                                   help="Size of extra disk space in GiB for "
+                                        "container layers and mounted volumes,"
+                                        " excluding 30GiB for OS and docker "
+                                        "runtime",
+                                   type=int, default=default.disk_size)
         submit_parser.add_argument("--processes", metavar = 20, help = "maximum multi processes", type = int, default = default.processes)
         submit_parser.add_argument("--processes-file-check", metavar = 10, help = "maximum multi processes for exists of iput files", type = int, default = default.processes_file_check)
         submit_parser.add_argument("--aws-security-group-id", metavar = "sg-ab123456,sg-ab456789", help = "AWS your security_group_ids, split with ',' ", type = str, default =  default.aws_security_group_id)

--- a/scripts/ecsub/aws.py
+++ b/scripts/ecsub/aws.py
@@ -53,7 +53,6 @@ class Aws_ecsub_control:
         self.aws_ecs_task_vcpu_default = 1
         self.aws_ecs_task_memory_default = 300
         self.disk_size = params["disk_size"]
-        self.root_disk_size = params["root_disk_size"]
         self.aws_subnet_id = params["aws_subnet_id"]
         self.image = params["image"]
         self.use_amazon_ecr = params["use_amazon_ecr"]
@@ -545,29 +544,13 @@ HOME=/
 */1 * * * * root /root/metricscript.sh
 */30 * * * * cat /dev/null > /var/spool/mail/root
 EOF
-
-cloud-init-per once mkfs_sdb mkfs -t ext4 /dev/sdb
-cloud-init-per once mkdir_external mkdir /external
-cloud-init-per once mount_sdb mount /dev/sdb /external
-
-echo "aws configure set aws_access_key_id "\$(aws configure get aws_access_key_id) > /external/aws_confgure.sh
-echo "aws configure set aws_secret_access_key "\$(aws configure get aws_secret_access_key) >> /external/aws_confgure.sh
-echo "aws configure set region "\$AWSREGION >> /external/aws_confgure.sh
 --==BOUNDARY==--
 """.format(cluster_arn = self.cluster_arn, region = self.aws_region)
     
     def _getblock_device_mappings(self):
         return [
             {
-                "DeviceName":"/dev/xvdcz",
-                "Ebs": {
-                    "VolumeSize": self.root_disk_size,
-                    "VolumeType": "gp2",
-                    "DeleteOnTermination":True
-                }
-            },
-            {
-                "DeviceName":"/dev/sdb",
+                "DeviceName":"/dev/xvda",
                 "Ebs": {
                     "VolumeSize": self.disk_size,
                     "VolumeType": "gp2",
@@ -1176,7 +1159,6 @@ echo "aws configure set region "\$AWSREGION >> /external/aws_confgure.sh
         response["tasks"][0]["log"] = log_html
         response["tasks"][0]["instance_type"] = self.task_param[no]["aws_ec2_instance_type"]
         response["tasks"][0]["disk_size"] = self.disk_size
-        response["tasks"][0]["root_disk_size"] = self.root_disk_size
         response["tasks"][0]["no"] = no
         response["tasks"][0]["instance_id"] = instance_id
         response["tasks"][0]["subnet_id"] = subnet_id

--- a/scripts/ecsub/aws_config.py
+++ b/scripts/ecsub/aws_config.py
@@ -7,7 +7,9 @@ Created on Tue Mar 20 12:54:32 2018
 
 def get_ami_id():
     import boto3
-    data=boto3.client("ssm").get_parameters(Names=["/aws/service/ecs/optimized-ami/amazon-linux/recommended/image_id"])
+    data = boto3.client("ssm").get_parameters(Names=[
+        "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id"
+    ])
     return data['Parameters'][0]['Value']
 
 def region_to_location(region):

--- a/scripts/ecsub/report.py
+++ b/scripts/ecsub/report.py
@@ -95,7 +95,7 @@ def _load_summary(params, dic_summary, header):
             info["task_endAt"] = data["End"]
             if info["task_endAt"] == None:
                 info["task_endAt"] = ""
-            info["disk_size"] = str(data["Ec2InstanceDiskSize"] + data["Ec2InstanceRootDiskSize"] + 8)
+            info["disk_size"] = str(data["Ec2InstanceDiskSize"])
             if "Price" in data:
                 info["price"] = str(data["Price"])
             

--- a/scripts/ecsub/submit.py
+++ b/scripts/ecsub/submit.py
@@ -480,7 +480,7 @@ def _save_summary_file(task_summary, print_cost):
     template_ec2 = " + instance-%d: $%.3f, instance-type %s (%s) $%.3f (if %s: $%.3f), running-time %.3f Hour"
     template_ebs = " + volume-%d: $%.3f, attached %d (GiB), $%.3f per GB-month of General Purpose SSD (gp2), running-time %.3f Hour"
     
-    disk_size = task_summary["Ec2InstanceDiskSize"] + task_summary["Ec2InstanceRootDiskSize"] + 8
+    disk_size = task_summary["Ec2InstanceDiskSize"]
     
     total_cost = 0.0
     items = []
@@ -525,7 +525,6 @@ def submit_task(ctx, thread_name, aws_instance, no, task_params, spot):
         "ClusterName": aws_instance.cluster_name,
         "ClusterArn": aws_instance.cluster_arn,
         "Ec2InstanceDiskSize": aws_instance.disk_size,
-        "Ec2InstanceRootDiskSize": aws_instance.root_disk_size,
         "EbsPrice": aws_instance.ebs_price,
         "End": None,
         "Image": aws_instance.image,
@@ -674,6 +673,11 @@ def main(params):
             print (ecsub.tools.error_message (params["cluster_name"], None, "disk-size %d is smaller than expected size 1GB." % (params["disk_size"])))
             return 1
             
+        # Adding requested disk size to the default EBS size of Amazon Linux 2
+        # AMI to be consistent with the previous versions of ecsub using
+        # Amazon Linux 1
+        params["disk_size"] += 30
+
         aws_instance = ecsub.aws.Aws_ecsub_control(params, len(task_params["tasks"]))
         
         # check task-param
@@ -856,7 +860,6 @@ class Argments:
         self.not_verify_bucket = False
         
         # The followings are not optional
-        self.root_disk_size = 22
         self.setx = "set -x"
         self.flyaway = False
         self.aws_account_id = ""

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -85,6 +85,21 @@ class SubmitTest(unittest.TestCase):
         ]
         subprocess.check_call(['python', 'ecsub', 'submit'] + options)
         
+    def test2_04_submit(self):
+        options = [
+            "--wdir", self.WDIR,
+            "--image", "python:2-alpine3.6",
+            "--shell", "ash",
+            "--script", "./tests/run-wordcount.sh",
+            "--tasks", "./tests/test-wordcount.tsv",
+            "--aws-ec2-instance-type", "t2.micro",
+            "--disk-size", "0",
+            "--aws-s3-bucket", "s3://travisci-work/wordcount/output/",
+            "--aws-log-group-name", "ecsub-travis2",
+        ]
+        self.assertEqual(1, subprocess.call(
+            ['python', 'ecsub', 'submit'] + options))
+
     def test3_01_report(self):
         options = [
             "--wdir", self.WDIR,


### PR DESCRIPTION
ecsubがEC2にインスタンスを立て際の、ベースイメージをAmazon Linux 2に変更します。
Amazon Linux 1 はサポートが切れるため、Amazon Linux 2に変更します。
https://aws.amazon.com/jp/blogs/news/update-on-amazon-linux-ami-end-of-life/

Amazon Linux 2 概要
- Amazon Linux AMI ：RedHat 6 → Amazon Linux 2 ：RedHat 7
- オンプレミスでの使用が可能
- Extras※1 によるパッケージのインストールが可能
- init システムの変更
- ファイルシステムの変更：Amazon Linux AMI：ext4 → Amazon Linux 2：xfs
https://aws.amazon.com/jp/amazon-linux-2/

これに合わせて、EBS のボリュームを１つにまとめます。
Amazon Linux 2 は Docker overlay2 ストレージドライバーを使用し、
ディスクの残っている容量のベースストレージサイズを使うことができます。
なので、OS等の領域と作業用の領域を合計サイズで一つのボリュームにするように変更します。
- 内部のサイズ変数を一本化
- ディスクサイズは、`disk-size`オプションで指定されたサイズにOSとdockerランタイムのための30GiBを加算
  - 30GiB：Amazon Linux 1 の際の  `/dev/xvda:8` と `/dev/xvdcz:22`に合わせています。

また、`disk-size`オプション で 0 以下の値が指定された場合にエラーになることの確認用のテストケースを追加します。

本PRによりecsub使用者への影響はありません。
（内部で使用できるディスクサイズは増えます）