### PR TITLE
Python3ベースのコンテナ起動時のエラー修正

### DIFF
--- a/scripts/ecsub/aws.py
+++ b/scripts/ecsub/aws.py
@@ -19,6 +19,24 @@ import glob
 import base64
 import pprint
 
+
+DEFAULT_SETUP_CONTAINER_CMD = """sh -c "
+if ! command -v aws > /dev/null; then
+    apt update;
+    if ! command -v curl > /dev/null; then
+        apt install -y --no-install-recommends curl
+    fi
+    if ! command -v unzip > /dev/null; then
+        apt install -y --no-install-recommends unzip
+    fi
+    curl -sS -o "awscliv2.zip" "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+    unzip -q awscliv2.zip
+    ./aws/install
+    rm -rf aws awscliv2.zip
+fi
+aws --version" """
+
+
 class Aws_ecsub_control:
 
     def __init__(self, params, task_num):
@@ -42,7 +60,7 @@ class Aws_ecsub_control:
         self.shell = params["shell"]
         self.setup_container_cmd = params["setup_container_cmd"]
         if self.setup_container_cmd == "":
-            self.setup_container_cmd = "apt update; apt install -y python-pip; pip install awscli --upgrade; aws configure list"
+            self.setup_container_cmd = DEFAULT_SETUP_CONTAINER_CMD
         self.dind = params["dind"]
         self.log_group_name = params["aws_log_group_name"]
         if self.log_group_name == "":

--- a/scripts/ecsub/submit.py
+++ b/scripts/ecsub/submit.py
@@ -841,7 +841,7 @@ class Argments:
         self.image = "python:2.7.14"
         self.use_amazon_ecr = False
         self.shell = "/bin/bash"
-        self.setup_container_cmd = "apt update; apt install -y python-pip; pip install awscli --upgrade; aws configure list"
+        self.setup_container_cmd = ecsub.aws.DEFAULT_SETUP_CONTAINER_CMD
         self.dind = False
         self.script = ""
         self.tasks = ""


### PR DESCRIPTION
Python3がインストールされたDockerイメージをecsubで起動しようとすると以下のようなエラーが発生します：

```
...
Unpacking python-pip (20.3.4+dfsg-4) ...
Setting up libpython2.7-stdlib:amd64 (2.7.18-13ubuntu1.1) ...
Setting up python2.7 (2.7.18-13ubuntu1.1) ...
Setting up libpython2-stdlib:amd64 (2.7.18-3) ...
Setting up python2 (2.7.18-3) ...
Setting up python-pkg-resources (44.1.1-1.2) ...
Setting up python-setuptools (44.1.1-1.2) ...
Setting up python-pip (20.3.4+dfsg-4) ...
/bin/bash: line 1: pip: command not found
/bin/bash: line 1: aws: command not found
/bin/bash: line 1: aws: command not found
/bin/bash: /run.sh: No such file or directory
```

これは、ecsubがコンテナ起動時にAWS CLIをインストールする際、[暗黙に`python-pip`をインストールしている](https://github.com/chrovis-genomon/ecsub/blob/1a872309e5f33b8dcf4cfe53238a5634c219e8ea/scripts/ecsub/aws.py#L45)ことに起因しているようです。`python-pip`のインストールは、環境にインストールされているPythonのバージョンによって挙動が変わり、

- Python2がインストールされている場合：何もしない
- Python3がインストールされている場合：`pip3`および(実体としては同じ)`pip`コマンドをアンインストールし、`pip2`コマンドをインストールする

という動作をします。これにより、Python3がインストールされている環境ではpipコマンドがアンインストールされるため、`apt install python-pip`に続いて実行される`pip install awscli`で`pip`コマンドが見つからずにエラーとなっているようです。

このプルリクエストは、コンテナ起動時に実行されるデフォルトコマンドを変更し、Python2および3のいずれがインストールされたコンテナでもエラーなくコンテナを起動できるよう修正します。

変更の基本的方針は以下の通りです：

- 環境にすでにAWS CLIがインストールされている場合は、新たにAWS CLIをインストールせず、インストールされているAWS CLIを利用する
- 環境にAWS CLIがインストールされていない場合は、AWS CLIの公式ダウンロードURLから直接インストーラをダウンロードし、AWS CLIをインストールする